### PR TITLE
Better writing with a blank

### DIFF
--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -380,7 +380,7 @@ class Citador {
   attachMention(user) {
     if (!$('form')[0]) return;
     ReactUtilities.getOwnerInstance($('form')[0]).setState({
-      textValue: ReactUtilities.getOwnerInstance($('form')[0]).state.textValue + `@${user.username}#${user.discriminator}`
+      textValue: ReactUtilities.getOwnerInstance($('form')[0]).state.textValue + `@${user.username}#${user.discriminator} `
     });
   }
   


### PR DESCRIPTION
This request adds a blank behind the new mention thing.
If someone quotes someone and wants to add the mention to the beginning he'll have to add a blank manually...
With this update, the blank is automatically there and allows it to start writing directly.