### PR TITLE
Update for internal module changes fixes #90

### DIFF
--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -96,11 +96,11 @@ class Citador {
     
     $(document).on("mouseover.citador", function(e) {
       let target = $(e.target);
-      if (target.parents(`.${DiscordClassModules.Messages.message}`).length > 0) {
-        $(`.${DiscordClassModules.Messages.messages} .${DiscordClassModules.Messages.container}`)
+      if (target.parents(`${DiscordSelectors.Messages.message}`).length > 0) {
+        $(`${DiscordSelectors.Messages.messages} ${DiscordSelectors.Messages.container}`)
           .on('mouseover', function() {
             if ($(this).find('.citar-btn').length == 0) {
-              $(`.${DiscordClassModules.Messages.messages} .${DiscordClassModules.Messages.container}`).hasClass(DiscordClassModules.Messages.containerCompact) 
+              $(`${DiscordSelectors.Messages.messages} ${DiscordSelectors.Messages.container}`).hasClass(`${DiscordClasses.Messages.containerCompact}`) 
                 ? $(this).find('time:not(.edited-DL9ECl)').first().prepend('<span class="citar-btn"></span>') 
                 : $(this).find('time:not(.edited-DL9ECl)').append('<span class="citar-btn"></span>');
                 
@@ -110,7 +110,7 @@ class Citador {
                 .click(function() {
                   self.attachParser();
                   
-                  let message = $(this).parents(`.${DiscordClassModules.Messages.container}`);
+                  let message = $(this).parents(`${DiscordSelectors.Messages.container}`);
                   
                   self.quoteProps = $.extend(true, {}, ReactUtilities.getOwnerInstance(message[0]).props);
                   
@@ -125,8 +125,8 @@ class Citador {
                     });
                     
                     $('.quote-msg').find(`.markup-2BOw-j`).each(function() {
-                      let index = $(`.quote-msg .${DiscordClassModules.Messages.message}`).index($(`.quote-msg .${DiscordClassModules.Messages.message}`).has(this));
-                      if (0 === self.quoteProps.messages[index].content.length + $(this).closest(`.${DiscordClassModules.Messages.message}`).find(`.container-1e22Ot`).length) {
+                      let index = $(`.quote-msg ${DiscordSelectors.Messages.message}`).index($(`.quote-msg ${DiscordSelectors.Messages.message}`).has(this));
+                      if (0 === self.quoteProps.messages[index].content.length + $(this).closest(`${DiscordSelectors.Messages.message}`).find(`.container-1e22Ot`).length) {
                         self.removeQuoteAtIndex(index);
                       }
                     });
@@ -134,28 +134,28 @@ class Citador {
                     $('.quote-msg').find(`.markup-2BOw-j`).before('<div class="delete-msg-btn"></div>');
                     $('.quote-msg').find(`.edited-DL9ECl, .buttonContainer-37UsAw .button-3Jq0g9, .btn-reaction`).remove();
                     
-                    $(`.quote-msg .${DiscordClassModules.Messages.container}`).prepend('<div class="quote-close"></div>');
+                    $(`.quote-msg ${DiscordSelectors.Messages.container}`).prepend('<div class="quote-close"></div>');
                     $('.quote-msg').find('.quote-close').click(() => self.cancelQuote());
                     
                     // define a função de clique, pra deletar uma mensagem que você não deseja citar
                     $('.quote-msg').find('.delete-msg-btn')
                       .click(function() {
-                        self.removeQuoteAtIndex($(`.quote-msg .${DiscordClassModules.Messages.message}`).index($(`.quote-msg .${DiscordClassModules.Messages.message}`).has(this)));
+                        self.removeQuoteAtIndex($(`.quote-msg ${DiscordSelectors.Messages.message}`).index($(`.quote-msg ${DiscordSelectors.Messages.message}`).has(this)));
                       })
                       .each(function() {
                         new PluginTooltip.Tooltip($(this), self.local.deleteTooltip);
                       });
                       
-                    ($(`.${DiscordClassModules.Messages.messages} .${DiscordClassModules.Messages.container}`).hasClass(DiscordClassModules.Messages.containerCompact) 
-                      ? $('.quote-msg').find(`.${DiscordClassModules.Messages.username}`)
-                      : $('.quote-msg').find(`.${DiscordClassModules.Messages.avatar}`))
+                    ($(`${DiscordSelectors.Messages.messages} ${DiscordSelectors.Messages.container}`).hasClass(`${DiscordClasses.Messages.containerCompact}`) 
+                      ? $('.quote-msg').find(`${DiscordSelectors.Messages.username}`)
+                      : $('.quote-msg').find(`${DiscordSelectors.Messages.avatar}`))
                       .click(function () {self.attachMention(self.quoteProps.messages[0].author)});
                     
                     if (self.settings.mentionUser) {
                       self.attachMention(self.quoteProps.messages[0].author);
                     }
 
-                    $('.quote-msg').find(`.${DiscordClassModules.Messages.message}`)
+                    $('.quote-msg').find(`${DiscordSelectors.Messages.message}`)
                       .on('mouseover.citador', function() {
                         $(this).find('.delete-msg-btn').fadeTo(5, 0.4);
                       })
@@ -175,8 +175,8 @@ class Citador {
                     messageElem.slideDown(150);
                   };
                   
-                  if ($(`.quote-msg .${DiscordClassModules.Messages.container}`).length > 0)
-                    $(`.quote-msg .${DiscordClassModules.Messages.container}`).remove();
+                  if ($(`.quote-msg ${DiscordSelectors.Messages.container}`).length > 0)
+                    $(`.quote-msg ${DiscordSelectors.Messages.container}`).remove();
                   else
                     $('.channelTextArea-1LDbYG').prepend('<div class="quote-msg"></div>');
                   
@@ -428,8 +428,8 @@ class Citador {
       if (this.quoteProps.messages.filter(m => !m.deleted).length < 2)
         this.cancelQuote();
       else {
-        let deleteMsg = $($(`.quote-msg .${DiscordClassModules.Messages.message}`)[i]);                
-        deleteMsg.find(`.${DiscordClassModules.Messages.content}, .container-1e22Ot`).hide();
+        let deleteMsg = $($(`.quote-msg ${DiscordSelectors.Messages.message}`)[i]);                
+        deleteMsg.find(`${DiscordSelectors.Messages.content}, .container-1e22Ot`).hide();
         this.quoteProps.messages[i].deleted = true;
       }
     } else
@@ -519,15 +519,15 @@ class Citador {
   
   deleteEverything() {
     $(document).off("mouseover.citador");
-    $(`.${DiscordClassModules.Messages.messages} .${DiscordClassModules.Messages.container}`).off('mouseover');
-    $(`.${DiscordClassModules.Messages.messages} .${DiscordClassModules.Messages.container}`).off('mouseleave');
+    $(`${DiscordSelectors.Messages.messages} ${DiscordSelectors.Messages.container}`).off('mouseover');
+    $(`${DiscordSelectors.Messages.messages} ${DiscordSelectors.Messages.container}`).off('mouseleave');
     this.remove("citador-css");
     this.initialized = false;
     this.cancel();
   }
   
   get guilds () {
-    return ReactUtilities.getOwnerInstance($(`.${DiscordClassModules.Guilds.guildsWrapper}`)[0]).props.guilds.map(o => o.guild);
+    return ReactUtilities.getOwnerInstance($(`${DiscordSelectors.Guilds.guildsWrapper}`)[0]).props.guilds.map(o => o.guild);
   }
   
   get defaultSettings() {


### PR DESCRIPTION
Changed Citador over to using the more versatile `DiscordSelectors` and `DiscordClasses` object, they can automatically parse and get the needed values from the internal classes since sometimes there are more than once class in the string so doing `.${DiscordClassModules.Something.className}` could yield `.class1 class2` which isn't a valid selector. This is why Citador broke. Fixes #90 