### PR TITLE
EmbedURL focus fix

### DIFF
--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -68,6 +68,7 @@ var Citador = (() => {
     this.moment            = WebpackModules.findByUniqueProperties(['parseZone']);
     this.initialized       = true;
     this.quoteURL          = 'https://github.com/nirewen/Citador?';
+    this.ClickURL          = 'https://discordapp.com/channels'
     this.CDN_URL           = 'https://cdn.discordapp.com/avatars/';
     this.ASSETS_URL        = 'https://discordapp.com';
 	DiscordClassModules.Messages.messages = WebpackModules.findByUniqueProperties(["messages"])
@@ -299,7 +300,7 @@ var Citador = (() => {
           author: {
             name: msg.nick || author.username,
             icon_url: avatarURL.startsWith(this.CDN_URL) ? avatarURL : `${this.ASSETS_URL}${avatarURL}`,
-            url: `${this.quoteURL}${msgG ? `guild_id=${msgG.id}&` : ''}channel_id=${msgC.id}&message_id=${msg.id}`,
+            url: `${this.ClickURL}/${msgG ? `${msgG.id}` : '@me'}/${msgC.id}/${msg.id}`,
           },
           description: text,
           footer: {


### PR DESCRIPTION
Fixes the current RichEmbed URL pattern so that clicking on the Embed title will focus on the original message