### PR TITLE
Fix guilds function and other general changes

### DIFF
--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -27,7 +27,7 @@ var Citador = (() => {
   
   getName         () { return "Citador";            }
   getDescription  () { return this.local.description}
-  getVersion      () { return "1.7.18";             }
+  getVersion      () { return "1.7.19";             }
   getAuthor       () { return "Nirewen";            }
   unload          () { this.deleteEverything();     }
   stop            () { this.deleteEverything();     }

--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -532,8 +532,10 @@ var Citador = (() => {
     this.cancel();
   }
   
-  get guilds () { /*unreadMentionBar does not lead to the guilds wrapper anymore*/
-    return ReactTools.getOwnerInstance($(`.${BdApi.findModuleByProps('wrapper','unreadMentionsBar','unreadMentionsIndicatorBottom','unreadMentionsIndicatorTop').wrapper.replace(/ /g, '.')}`)[0]).props.guilds.map(o => o.guild)||ReactTools.getOwnerInstance(document.getElementsByClassName('wrapper-1Rf91z')[0]).props.guilds.map(o => o.guild);
+  get guilds () { /*unreadMentionBar does not lead to the guilds wrapper anymore. Added a check to see if it grabbed the right module, and if it can't then use a manually written backup.*/
+	let grabByProps=BdApi.findModuleByProps('wrapper','unreadMentionsBar','unreadMentionsIndicatorBottom','unreadMentionsIndicatorTop'),manualBackup='wrapper-1Rf91z';
+	if(grabByProps)return ReactTools.getOwnerInstance($(`.${grabByProps.wrapper.replace(/ /g, '.')}`)[0]).props.guilds.map(o => o.guild);
+	else if(document.getElementsByClassName(manualBackup)[0])return ReactTools.getOwnerInstance(document.getElementsByClassName(manualBackup)[0]).props.guilds.map(o => o.guild);
   }
   
   get defaultSettings() {

--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -1,4 +1,4 @@
-//META{"name":"Citador"}*//
+//META{"name":"Citador","source":"https://github.com/nirewen/Citador/blob/master/Citador.plugin.js","website":"https://github.com/nirewen"}*//
 
 /* global $, Element */
 

--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -32,15 +32,15 @@ var Citador = (() => {
   unload          () { this.deleteEverything();     }
   stop            () { this.deleteEverything();     }
   load            () {
-	let libraryScript=document.getElementById('ZLibraryScript');
-	if(!window.ZLibrary&&!libraryScript){
-		libraryScript=document.createElement('script');
-		libraryScript.setAttribute('type','text/javascript');
-		libraryScript.addEventListener("error",function(){if(typeof window.ZLibrary==="undefined"){window.BdApi.alert("Library Missing",`The library plugin needed for ${this.getName()} is missing and could not be loaded.<br /><br /><a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}}.bind(this));
-		libraryScript.setAttribute('src','https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js');
-		libraryScript.setAttribute('id','ZLibraryScript');
-		document.head.appendChild(libraryScript);
-	}
+		let libraryScript=document.getElementById('ZLibraryScript');
+		if(!window.ZLibrary&&!libraryScript){
+			libraryScript=document.createElement('script');
+			libraryScript.setAttribute('type','text/javascript');
+			libraryScript.addEventListener("error",function(){if(typeof window.ZLibrary==="undefined"){window.BdApi.alert("Library Missing",`The library plugin needed for ${this.getName()} is missing and could not be loaded.<br /><br /><a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}}.bind(this));
+			libraryScript.setAttribute('src','https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js');
+			libraryScript.setAttribute('id','ZLibraryScript');
+			document.head.appendChild(libraryScript);
+		}
   }
   async start     () {
     this.inject('link', {
@@ -532,8 +532,8 @@ var Citador = (() => {
     this.cancel();
   }
   
-  get guilds () {
-    return ReactTools.getOwnerInstance($('.' + BdApi.findModuleByProps('unreadMentionBar', 'unreadMentionsBar', 'wrapper').wrapper.replace(/ /g, '.'))[0]).props.guilds.map(o => o.guild);
+  get guilds () { /*wrapper and unreadMentionBar do not lead to the guilds wrapper anymore*/
+    return ReactTools.getOwnerInstance($(`.${BdApi.findModuleByProps('unreadMentionsBar','unreadMentionsIndicatorBottom','unreadMentionsIndicatorTop').wrapper.replace(/ /g, '.')}`)[0]).props.guilds.map(o => o.guild)||ReactTools.getOwnerInstance(document.getElementsByClassName('wrapper-1Rf91z')[0]).props.guilds.map(o => o.guild);
   }
   
   get defaultSettings() {

--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -31,13 +31,18 @@ var Citador = (() => {
   getAuthor       () { return "Nirewen";            }
   unload          () { this.deleteEverything();     }
   stop            () { this.deleteEverything();     }
-  load            () {                              }
+  load            () {
+	let libraryScript=document.getElementById('ZLibraryScript');
+	if(!window.ZLibrary&&!libraryScript){
+		libraryScript=document.createElement('script');
+		libraryScript.setAttribute('type','text/javascript');
+		libraryScript.addEventListener("error",function(){if(typeof window.ZLibrary==="undefined"){window.BdApi.alert("Library Missing",`The library plugin needed for ${this.getName()} is missing and could not be loaded.<br /><br /><a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}}.bind(this));
+		libraryScript.setAttribute('src','https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js');
+		libraryScript.setAttribute('id','ZLibraryScript');
+		document.head.appendChild(libraryScript);
+	}
+  }
   async start     () {
-    let libraryScript = this.inject('script', {
-      type: 'text/javascript',
-      id: 'zeresLibraryScript',
-      src: 'https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js'
-    });
     this.inject('link', {
       type: 'text/css',
       id: 'citador-css',
@@ -45,13 +50,11 @@ var Citador = (() => {
       href: 'https://rawcdn.githack.com/nirewen/Citador/master/Citador.styles.css?v=2'
     });
 
-    if (!this.strings) 
-      this.strings = await this.downloadJSON("https://raw.githubusercontent.com/nirewen/Citador/master/Citador.locales.json");
+    if(!this.strings)this.strings=await this.downloadJSON("https://raw.githubusercontent.com/nirewen/Citador/master/Citador.locales.json");
 
-    if (typeof window.ZLibrary !== "undefined") 
-      this.initialize();
-    else 
-      libraryScript.addEventListener("load", () => this.initialize());
+	let libraryScript=document.getElementById('ZLibraryScript');
+    if(typeof window.ZLibrary!=="undefined")this.initialize();
+    else libraryScript.addEventListener("load",()=>this.initialize());
   }
   
   initialize() {

--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -532,8 +532,8 @@ var Citador = (() => {
     this.cancel();
   }
   
-  get guilds () { /*wrapper and unreadMentionBar do not lead to the guilds wrapper anymore*/
-    return ReactTools.getOwnerInstance($(`.${BdApi.findModuleByProps('unreadMentionsBar','unreadMentionsIndicatorBottom','unreadMentionsIndicatorTop').wrapper.replace(/ /g, '.')}`)[0]).props.guilds.map(o => o.guild)||ReactTools.getOwnerInstance(document.getElementsByClassName('wrapper-1Rf91z')[0]).props.guilds.map(o => o.guild);
+  get guilds () { /*unreadMentionBar do not lead to the guilds wrapper anymore*/
+    return ReactTools.getOwnerInstance($(`.${BdApi.findModuleByProps('wrapper','unreadMentionsBar','unreadMentionsIndicatorBottom','unreadMentionsIndicatorTop').wrapper.replace(/ /g, '.')}`)[0]).props.guilds.map(o => o.guild)||ReactTools.getOwnerInstance(document.getElementsByClassName('wrapper-1Rf91z')[0]).props.guilds.map(o => o.guild);
   }
   
   get defaultSettings() {

--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -532,7 +532,7 @@ var Citador = (() => {
     this.cancel();
   }
   
-  get guilds () { /*unreadMentionBar do not lead to the guilds wrapper anymore*/
+  get guilds () { /*unreadMentionBar does not lead to the guilds wrapper anymore*/
     return ReactTools.getOwnerInstance($(`.${BdApi.findModuleByProps('wrapper','unreadMentionsBar','unreadMentionsIndicatorBottom','unreadMentionsIndicatorTop').wrapper.replace(/ /g, '.')}`)[0]).props.guilds.map(o => o.guild)||ReactTools.getOwnerInstance(document.getElementsByClassName('wrapper-1Rf91z')[0]).props.guilds.map(o => o.guild);
   }
   


### PR DESCRIPTION
In the guilds function, "unreadMentionBar" is no longer a prop of the guilds wrapper. It prevents the plugin from grabbing guilds and thereby preventing it from working properly. Added checks to see if it was able to grab the module and a manual backup in the case where it cannot grab the module but the class has not changed.

The addition of the load function is to help solve an issue where adding the remote library to the header w/o checking for the library plugin can cause issues. Sometimes adding the remote lib when it is unneeded can break all zLibrary settings panels from any plugin.