### PR TITLE
Make use of the new block quotes

### DIFF
--- a/Citador.plugin.js
+++ b/Citador.plugin.js
@@ -395,7 +395,7 @@ var Citador = (() => {
       }
       
       const format = 'DD-MM-YYYY HH:mm';
-      content     += `\n${'```'}\n${this.MessageParser.unparse(text, cc.id).replace(/\n?(```((\w+)?\n)?)+/g, '\n').trim()}\n${'```'}`;
+      content     += `\n${'> '}${this.MessageParser.unparse(text, cc.id).replace(/\n?(```((\w+)?\n)?)+/g, '\n').replace(/\n/g, '\n> ').trim()}\n`;
       content     += `\`${msg.nick || author.username} - ${this.moment(msg.timestamp).format(format)} | ${chName}${atServer}\``;
       content      = content.trim();
           


### PR DESCRIPTION
This is a small change I've made to utilize block quotes instead of old code blocks. Block quotes have an advantage of actually displaying emojis (and they also look nicer!)
Of course this simple pull request obviously doesn't have all the changes that are needed (translation file update for example), but I'd like the original author to consider utilizing block quotes.